### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -74,12 +74,12 @@ def _check_key(key, key_prefix=b''):
         try:
             key = key.encode('ascii')
         except UnicodeEncodeError:
-            raise MemcacheIllegalInputError("No ascii key: %r" % (key,))
+            raise MemcacheIllegalInputError("No ascii key: {0!r}".format(key))
     key = key_prefix + key
     if b' ' in key:
-        raise MemcacheIllegalInputError("Key contains spaces: %r" % (key,))
+        raise MemcacheIllegalInputError("Key contains spaces: {0!r}".format(key))
     if len(key) > 250:
-        raise MemcacheIllegalInputError("Key is too long: %r" % (key,))
+        raise MemcacheIllegalInputError("Key is too long: {0!r}".format(key))
     return key
 
 
@@ -609,7 +609,7 @@ class Client(object):
         result = self._misc_cmd(cmd, b'version', False)
 
         if not result.startswith(b'VERSION '):
-            raise MemcacheUnknownError("Received unexpected response: %s" % (result, ))
+            raise MemcacheUnknownError("Received unexpected response: {0!s}".format(result ))
 
         return result[8:]
 
@@ -685,8 +685,7 @@ class Client(object):
                         try:
                             _, key, flags, size = line.split()
                         except Exception as e:
-                            raise ValueError("Unable to parse line %s: %s"
-                                             % (line, str(e)))
+                            raise ValueError("Unable to parse line {0!s}: {1!s}".format(line, str(e)))
 
                     buf, value = _readvalue(self.sock, buf, int(size))
                     key = checked_keys[key]

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -92,7 +92,7 @@ class HashClient(object):
             self.add_server(server, port)
 
     def add_server(self, server, port):
-        key = '%s:%s' % (server, port)
+        key = '{0!s}:{1!s}'.format(server, port)
 
         if self.use_pooling:
             client = PooledClient(
@@ -109,7 +109,7 @@ class HashClient(object):
         dead_time = time.time()
         self._failed_clients.pop((server, port))
         self._dead_clients[(server, port)] = dead_time
-        key = '%s:%s' % (server, port)
+        key = '{0!s}:{1!s}'.format(server, port)
         self.hasher.remove_node(key)
 
     def _get_client(self, key):
@@ -257,7 +257,7 @@ class HashClient(object):
             client_batches[client.server][key] = value
 
         for server, values in client_batches.items():
-            client = self.clients['%s:%s' % server]
+            client = self.clients['{0!s}:{1!s}'.format(*server)]
             new_args = list(args)
             new_args.insert(0, values)
             result = self._safely_run_func(
@@ -287,7 +287,7 @@ class HashClient(object):
             client_batches[client.server].append(key)
 
         for server, keys in client_batches.items():
-            client = self.clients['%s:%s' % server]
+            client = self.clients['{0!s}:{1!s}'.format(*server)]
             new_args = list(args)
             new_args.insert(0, keys)
             result = self._safely_run_func(

--- a/pymemcache/client/rendezvous.py
+++ b/pymemcache/client/rendezvous.py
@@ -28,7 +28,7 @@ class RendezvousHash(object):
         if node in self.nodes:
             self.nodes.remove(node)
         else:
-            raise ValueError("No such node %s to remove" % (node))
+            raise ValueError("No such node {0!s} to remove".format((node)))
 
     def get_node(self, key):
         high_score = -1
@@ -36,7 +36,7 @@ class RendezvousHash(object):
 
         for node in self.nodes:
             score = self.hash_function(
-                "%s-%s" % (str(node), str(key)))
+                "{0!s}-{1!s}".format(str(node), str(key)))
 
             if score > high_score:
                 (high_score, winner) = (score, node)

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -33,10 +33,10 @@ def python_memcache_serializer(key, value):
         pass
     elif isinstance(value, int):
         flags |= FLAG_INTEGER
-        value = "%d" % value
+        value = "{0:d}".format(value)
     elif isinstance(value, long):
         flags |= FLAG_LONG
-        value = "%d" % value
+        value = "{0:d}".format(value)
     else:
         flags |= FLAG_PICKLE
         output = StringIO()

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -25,7 +25,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         ip = '127.0.0.1'
 
         for vals in mock_socket_values:
-            s = '%s:%s' % (ip, current_port)
+            s = '{0!s}:{1!s}'.format(ip, current_port)
             c = self.make_client_pool(
                 (ip, current_port),
                 vals


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pymemcache?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pymemcache?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
